### PR TITLE
Off-by-one in line number when using python >= 2.6

### DIFF
--- a/src/z3c/coverage/coveragereport.py
+++ b/src/z3c/coverage/coveragereport.py
@@ -183,7 +183,7 @@ class CoverageCoverageNode(CoverageNode):
         OTHER     = '       '
         lines = []
         f = open(self.source_filename)
-        for n, line in enumerate(f, start=1):
+        for n, line in enumerate(f):
             n += 1  # workaround: no enumerate(f, start=1) support in 2.4/5
             if n in self._missing:      prefix = MISSING
             elif n in self._excluded:   prefix = EXCLUDED


### PR DESCRIPTION
'start' parameter is ignored by python <= 2.5, that's why line 187 includes a workaround.
But this generates a bug for python >= 2.6.